### PR TITLE
io_uring backend fixes

### DIFF
--- a/.github/workflows/single_include.yml
+++ b/.github/workflows/single_include.yml
@@ -24,6 +24,7 @@ jobs:
       run: g++ -DFMT_HEADER_ONLY -DXTR_USE_IO_URING=0 -std=c++20 -Wall -pedantic test/single_include.cpp -I single_include -isystem third_party/include -pthread -o /dev/null
 
     - name: Commit changes
+      if: github.event_name == 'push'
       uses: EndBug/add-and-commit@v9
       with:
         author_name: github-actions

--- a/.github/workflows/single_include.yml
+++ b/.github/workflows/single_include.yml
@@ -24,7 +24,7 @@ jobs:
       run: g++ -DFMT_HEADER_ONLY -DXTR_USE_IO_URING=0 -std=c++20 -Wall -pedantic test/single_include.cpp -I single_include -isystem third_party/include -pthread -o /dev/null
 
     - name: Commit changes
-      if: github.event_name == 'push'
+      if: github.ref == 'refs/heads/master'
       uses: EndBug/add-and-commit@v9
       with:
         author_name: github-actions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ add_library(${PROJECT_NAME} src/buffer.cpp
                             src/matcher.cpp
                             src/memory_mapping.cpp
                             src/mirrored_memory_mapping.cpp
+                            src/open.cpp
                             src/pagesize.cpp
                             src/posix_fd_storage.cpp
                             src/regex_matcher.cpp

--- a/Makefile
+++ b/Makefile
@@ -138,9 +138,9 @@ SRCS := \
 	src/buffer.cpp src/fd_storage.cpp src/fd_storage_base.cpp \
 	src/file_descriptor.cpp src/io_uring_fd_storage.cpp src/logger.cpp \
 	src/log_level.cpp src/matcher.cpp src/memory_mapping.cpp \
-	src/mirrored_memory_mapping.cpp src/pagesize.cpp src/posix_fd_storage.cpp \
-	src/regex_matcher.cpp src/sink.cpp src/throw.cpp \
-	src/tsc.cpp src/wildcard_matcher.cpp
+	src/mirrored_memory_mapping.cpp src/open.cpp src/pagesize.cpp \
+	src/posix_fd_storage.cpp src/regex_matcher.cpp src/sink.cpp \
+	src/throw.cpp src/tsc.cpp src/wildcard_matcher.cpp
 
 OBJS = $(SRCS:%=$(BUILD_DIR)/%.o)
 

--- a/include/xtr/io/detail/fd_storage_base.hpp
+++ b/include/xtr/io/detail/fd_storage_base.hpp
@@ -41,7 +41,7 @@ public:
     int reopen() noexcept override;
 
 protected:
-    virtual void replace_fd(int newfd) noexcept;
+    virtual void replace_fd(file_descriptor fd) noexcept;
 
     std::string reopen_path_;
     detail::file_descriptor fd_;

--- a/include/xtr/io/detail/open.hpp
+++ b/include/xtr/io/detail/open.hpp
@@ -1,0 +1,29 @@
+// Copyright 2026 Chris E. Holloway
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef XTR_IO_DETAIL_OPEN_HPP
+#define XTR_IO_DETAIL_OPEN_HPP
+
+namespace xtr::detail
+{
+    int open_at_end(const char* path);
+}
+
+#endif

--- a/include/xtr/io/detail/open.hpp
+++ b/include/xtr/io/detail/open.hpp
@@ -21,9 +21,17 @@
 #ifndef XTR_IO_DETAIL_OPEN_HPP
 #define XTR_IO_DETAIL_OPEN_HPP
 
+#include "xtr/detail/file_descriptor.hpp"
+
 namespace xtr::detail
 {
-    int open_at_end(const char* path);
+    file_descriptor open_at_end(const char* path) noexcept;
+
+    bool is_seekable(int fd) noexcept;
+
+    bool is_append(int fd) noexcept;
+
+    bool set_append(int fd) noexcept;
 }
 
 #endif

--- a/include/xtr/io/fd_storage.hpp
+++ b/include/xtr/io/fd_storage.hpp
@@ -23,7 +23,7 @@
 
 #include "xtr/io/storage_interface.hpp"
 
-#include <cstddef>
+#include <cstdio>
 #include <string>
 
 namespace xtr

--- a/include/xtr/io/io_uring_fd_storage.hpp
+++ b/include/xtr/io/io_uring_fd_storage.hpp
@@ -144,6 +144,8 @@ public:
 protected:
     void replace_fd(int newfd) noexcept final;
 
+    void set_offset() noexcept;
+
 private:
     void allocate_buffers(std::size_t queue_size);
 

--- a/include/xtr/io/io_uring_fd_storage.hpp
+++ b/include/xtr/io/io_uring_fd_storage.hpp
@@ -37,6 +37,25 @@
 namespace xtr
 {
     class io_uring_fd_storage;
+
+    namespace detail
+    {
+        class unique_io_uring
+        {
+        public:
+            explicit unique_io_uring(std::size_t queue_size);
+
+            unique_io_uring(const unique_io_uring&) = delete;
+            unique_io_uring& operator=(const unique_io_uring&) = delete;
+
+            ~unique_io_uring();
+
+            io_uring* get() noexcept;
+
+        private:
+            io_uring ring_;
+        };
+    }
 }
 
 /**
@@ -66,7 +85,7 @@ private:
     struct buffer
     {
         int index_;     // io_uring_prep_write_fixed accepts indexes as int
-        unsigned size_; // io_uring_cqe::res is an unsigned int
+        unsigned size_; // io_uring_cqe::res is an int
         std::size_t offset_;
         std::size_t file_offset_;
         buffer* next_;
@@ -109,7 +128,8 @@ public:
      * @param fd: File descriptor to write to. This will be duplicated via a
      * call to <a href="https://www.man7.org/linux/man-pages/man2/dup.2.html">dup(2)</a>,
      * so callers may close the file descriptor immediately after this
-     * constructor returns if desired.
+     * constructor returns if desired. The file descriptor must be seekable
+     * and must not have O_APPEND set.
      *
      * @param reopen_path: The path of the file associated with the fd argument.
      * This path will be used to reopen the file if requested via the xtrctl
@@ -142,7 +162,7 @@ public:
     void submit_buffer(char* data, std::size_t size) final;
 
 protected:
-    void replace_fd(int newfd) noexcept final;
+    void replace_fd(detail::file_descriptor fd) noexcept final;
 
     void set_offset() noexcept;
 
@@ -157,7 +177,7 @@ private:
 
     void free_buffer(buffer* buf);
 
-    io_uring ring_;
+    detail::unique_io_uring ring_;
     std::size_t buffer_capacity_;
     std::size_t batch_size_;
     std::size_t batch_index_ = 0;

--- a/include/xtr/io/posix_fd_storage.hpp
+++ b/include/xtr/io/posix_fd_storage.hpp
@@ -73,6 +73,9 @@ public:
     {
     }
 
+protected:
+    void replace_fd(detail::file_descriptor fd) noexcept final;
+
 private:
     std::unique_ptr<char[]> buf_;
     std::size_t buffer_capacity_;

--- a/include/xtr/logger.hpp
+++ b/include/xtr/logger.hpp
@@ -344,7 +344,8 @@ public:
      * to @ref logger::logger then this function must be called in order to
      * process messages written to the logger. Users may call this function from
      * a thread of their choosing and may interleave calls with other background
-     * tasks that their program needs to perform.
+     * tasks that their program needs to perform. Once it has been called from
+     * a given thread it must continue to be called from the same thread.
      *
      * For best results when interleaving with other tasks ensure that io_uring
      * mode is enabled (so that I/O will be performed asynchronously leaving

--- a/scripts/make_single_include.sh
+++ b/scripts/make_single_include.sh
@@ -61,6 +61,7 @@ for file in \
     include/xtr/io/detail/fd_storage_base.hpp \
     include/xtr/io/posix_fd_storage.hpp \
     include/xtr/io/io_uring_fd_storage.hpp \
+    include/xtr/io/detail/open.hpp \
     include/xtr/io/fd_storage.hpp \
     include/xtr/logger.hpp \
     include/xtr/detail/concepts.hpp \
@@ -84,6 +85,7 @@ grep -hEv '^ *//|^#include "' \
     src/matcher.cpp \
     src/memory_mapping.cpp \
     src/mirrored_memory_mapping.cpp \
+    src/open.cpp \
     src/pagesize.cpp \
     src/posix_fd_storage.cpp \
     src/regex_matcher.cpp \

--- a/single_include/xtr/logger.hpp
+++ b/single_include/xtr/logger.hpp
@@ -851,7 +851,11 @@ public:
 
     void reduce_readable(size_type nbytes) noexcept
     {
-        nread_plus_capacity_.fetch_add(nbytes, std::memory_order_release);
+
+        nread_plus_capacity_.store(
+            nread_plus_capacity_.load(std::memory_order_relaxed) + nbytes,
+            std::memory_order_release);
+
 #if !defined(XTR_THREAD_SANITIZER_ENABLED)
         assert(nread_plus_capacity_.load() - nwritten_.load() <= capacity());
 #endif
@@ -1695,8 +1699,8 @@ namespace xtr
 class xtr::sink
 {
 private:
-    using fptr_t = std::byte* (*)(detail::buffer& buf, // output buffer
-                                  std::byte* record,   // pointer to log record
+    using fptr_t = std::byte* (*)(detail::buffer & buf, // output buffer
+                                  std::byte* record,    // pointer to log record
                                   detail::consumer&,
                                   const char* timestamp,
                                   std::string& name) noexcept;
@@ -2352,7 +2356,7 @@ public:
     {
     }
 
-    virtual ~matcher(){};
+    virtual ~matcher() {};
 };
 
 #include <cstddef>
@@ -2808,7 +2812,7 @@ public:
     int reopen() noexcept override;
 
 protected:
-    virtual void replace_fd(int newfd) noexcept;
+    virtual void replace_fd(file_descriptor fd) noexcept;
 
     std::string reopen_path_;
     detail::file_descriptor fd_;
@@ -2864,6 +2868,9 @@ public:
     {
     }
 
+protected:
+    void replace_fd(detail::file_descriptor fd) noexcept final;
+
 private:
     std::unique_ptr<char[]> buf_;
     std::size_t buffer_capacity_;
@@ -2881,6 +2888,25 @@ private:
 namespace xtr
 {
     class io_uring_fd_storage;
+
+    namespace detail
+    {
+        class unique_io_uring
+        {
+        public:
+            explicit unique_io_uring(std::size_t queue_size);
+
+            unique_io_uring(const unique_io_uring&) = delete;
+            unique_io_uring& operator=(const unique_io_uring&) = delete;
+
+            ~unique_io_uring();
+
+            io_uring* get() noexcept;
+
+        private:
+            io_uring ring_;
+        };
+    }
 }
 
 /**
@@ -2910,7 +2936,7 @@ private:
     struct buffer
     {
         int index_;     // io_uring_prep_write_fixed accepts indexes as int
-        unsigned size_; // io_uring_cqe::res is an unsigned int
+        unsigned size_; // io_uring_cqe::res is an int
         std::size_t offset_;
         std::size_t file_offset_;
         buffer* next_;
@@ -2953,7 +2979,8 @@ public:
      * @param fd: File descriptor to write to. This will be duplicated via a
      * call to <a href="https://www.man7.org/linux/man-pages/man2/dup.2.html">dup(2)</a>,
      * so callers may close the file descriptor immediately after this
-     * constructor returns if desired.
+     * constructor returns if desired. The file descriptor must be seekable
+     * and must not have O_APPEND set.
      *
      * @param reopen_path: The path of the file associated with the fd argument.
      * This path will be used to reopen the file if requested via the xtrctl
@@ -2986,7 +3013,9 @@ public:
     void submit_buffer(char* data, std::size_t size) final;
 
 protected:
-    void replace_fd(int newfd) noexcept final;
+    void replace_fd(detail::file_descriptor fd) noexcept final;
+
+    void set_offset() noexcept;
 
 private:
     void allocate_buffers(std::size_t queue_size);
@@ -2999,7 +3028,7 @@ private:
 
     void free_buffer(buffer* buf);
 
-    io_uring ring_;
+    detail::unique_io_uring ring_;
     std::size_t buffer_capacity_;
     std::size_t batch_size_;
     std::size_t batch_index_ = 0;
@@ -3016,7 +3045,18 @@ private:
 
 #endif
 
-#include <cstddef>
+namespace xtr::detail
+{
+    file_descriptor open_at_end(const char* path) noexcept;
+
+    bool is_seekable(int fd) noexcept;
+
+    bool is_append(int fd) noexcept;
+
+    bool set_append(int fd) noexcept;
+}
+
+#include <cstdio>
 #include <string>
 
 namespace xtr
@@ -3440,6 +3480,7 @@ namespace xtr::detail
 
     template<typename T>
     concept tuple_like = requires(T t) { std::tuple_size<T>(); };
+
 }
 
 #include <algorithm>
@@ -3791,10 +3832,11 @@ inline void xtr::detail::command_dispatcher::send(
 
 inline void xtr::detail::command_dispatcher::process_commands(int timeout) noexcept
 {
-    int nfds = XTR_TEMP_FAILURE_RETRY(::poll(
-        reinterpret_cast<::pollfd*>(&pollfds_[0]),
-        ::nfds_t(pollfds_.size()),
-        timeout));
+    int nfds = XTR_TEMP_FAILURE_RETRY(
+        ::poll(
+            reinterpret_cast<::pollfd*>(&pollfds_[0]),
+            ::nfds_t(pollfds_.size()),
+            timeout));
 
     if (nfds == -1)
     {
@@ -4231,22 +4273,19 @@ inline int xtr::detail::fd_storage_base::reopen() noexcept
     if (reopen_path_ == null_reopen_path)
         return ENOENT;
 
-    const int newfd = XTR_TEMP_FAILURE_RETRY(::open(
-        reopen_path_.c_str(),
-        O_CREAT | O_APPEND | O_WRONLY,
-        S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH));
+    auto fd = detail::open_at_end(reopen_path_.c_str());
 
-    if (newfd == -1)
+    if (!fd)
         return errno;
 
-    replace_fd(newfd);
+    replace_fd(std::move(fd));
 
     return 0;
 }
 
-inline void xtr::detail::fd_storage_base::replace_fd(int newfd) noexcept
+inline void xtr::detail::fd_storage_base::replace_fd(file_descriptor fd) noexcept
 {
-    fd_.reset(newfd);
+    fd_ = std::move(fd);
 }
 
 #include <fmt/compile.h>
@@ -4254,33 +4293,66 @@ inline void xtr::detail::fd_storage_base::replace_fd(int newfd) noexcept
 
 #include <cerrno>
 #include <memory>
+#include <string_view>
 #include <utility>
 
-#include <fcntl.h>
-#include <sys/stat.h>
+#include <sys/mman.h>
 #include <sys/syscall.h>
 #include <unistd.h>
 
 namespace xtr::detail
 {
-    inline bool is_seekable(int fd)
+#if XTR_USE_IO_URING
+    inline bool is_io_uring_working()
     {
-        struct ::stat st;
-        return ::fstat(fd, &st) == 0 && S_ISREG(st.st_mode);
+        constexpr std::string_view magic = "io_uring is working";
+        constexpr std::size_t buf_capacity = 32;
+
+        file_descriptor memfd(::memfd_create("xtr_health_check", MFD_CLOEXEC));
+
+        if (!memfd)
+            return false;
+
+#if __cpp_exceptions
+        try
+#endif
+        {
+            io_uring_fd_storage storage(
+                memfd.get(),
+                null_reopen_path,
+                buf_capacity,
+                /* queue_size= */ 2,
+                /* batch_size= */ 1);
+            const std::span<char> span = storage.allocate_buffer();
+            magic.copy(span.data(), magic.size());
+            storage.submit_buffer(span.data(), magic.size());
+            storage.sync();
+        }
+#if __cpp_exceptions
+        catch (const std::exception&)
+        {
+            return false;
+        }
+#endif
+
+        char buf[buf_capacity];
+        const ::ssize_t nread = ::pread(memfd.get(), buf, sizeof(buf), 0);
+        return nread >= 0 && std::string_view(buf, std::size_t(nread)) == magic;
     }
+#endif
+
+    storage_interface_ptr make_fd_storage(
+        int fd, std::string reopen_path, bool fd_created);
 }
 
 inline xtr::storage_interface_ptr xtr::make_fd_storage(const char* path)
 {
-    const int fd = XTR_TEMP_FAILURE_RETRY(::open(
-        path,
-        O_CREAT | O_APPEND | O_WRONLY,
-        S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH));
+    const auto fd = detail::open_at_end(path);
 
-    if (fd == -1)
+    if (!fd)
         detail::throw_system_error_fmt(errno, "Failed to open `%s'", path);
 
-    return make_fd_storage(fd, path);
+    return detail::make_fd_storage(fd.get(), path, /* fd_created= */ true);
 }
 
 inline xtr::storage_interface_ptr xtr::make_fd_storage(FILE* fp, std::string reopen_path)
@@ -4290,11 +4362,19 @@ inline xtr::storage_interface_ptr xtr::make_fd_storage(FILE* fp, std::string reo
 
 inline xtr::storage_interface_ptr xtr::make_fd_storage(int fd, std::string reopen_path)
 {
+    return detail::make_fd_storage(fd, std::move(reopen_path), /* fd_created= */ false);
+}
+
+inline xtr::storage_interface_ptr xtr::detail::make_fd_storage(
+    int fd, std::string reopen_path, bool fd_created)
+{
 #if XTR_USE_IO_URING
     errno = 0;
     (void)syscall(__NR_io_uring_setup, 0, nullptr);
+    const bool has_io_uring = errno != ENOSYS;
 
-    if (detail::is_seekable(fd) && errno != ENOSYS)
+    if (has_io_uring && detail::is_seekable(fd) && !detail::is_append(fd) &&
+        detail::is_io_uring_working())
     {
 #if __cpp_exceptions
         try
@@ -4307,13 +4387,23 @@ inline xtr::storage_interface_ptr xtr::make_fd_storage(int fd, std::string reope
         {
             fmt::print(
                 stderr,
-                FMT_COMPILE("Falling back to posix_fd_storage due to "
-                            "io_uring_fd_storage error: {}\n"),
+                FMT_COMPILE(
+                    "Falling back to posix_fd_storage due to "
+                    "io_uring_fd_storage error: {}\n"),
                 e.what());
         }
 #endif
     }
 #endif
+
+    if (fd_created && !detail::set_append(fd))
+    {
+        detail::throw_system_error_fmt(
+            errno,
+            "Failed to set O_APPEND on `%s'",
+            reopen_path.c_str());
+    }
+
     return std::make_unique<posix_fd_storage>(fd, std::move(reopen_path));
 }
 
@@ -4363,6 +4453,36 @@ inline void xtr::detail::file_descriptor::reset(int fd) noexcept
 #include <limits>
 #include <vector>
 
+#include <unistd.h>
+
+inline xtr::detail::unique_io_uring::unique_io_uring(std::size_t queue_size)
+{
+    const int flags =
+#if XTR_IO_URING_POLL
+        IORING_SETUP_SQPOLL;
+#else
+        0;
+#endif
+
+    if (const int errnum =
+            ::io_uring_queue_init(unsigned(queue_size), &ring_, flags))
+    {
+        throw_system_error_fmt(
+            -errnum,
+            "xtr::detail::unique_io_uring: io_uring_queue_init failed");
+    }
+}
+
+inline xtr::detail::unique_io_uring::~unique_io_uring()
+{
+    ::io_uring_queue_exit(&ring_);
+}
+
+inline io_uring* xtr::detail::unique_io_uring::get() noexcept
+{
+    return &ring_;
+}
+
 inline xtr::io_uring_fd_storage::io_uring_fd_storage(
     int fd,
     std::string reopen_path,
@@ -4375,6 +4495,7 @@ inline xtr::io_uring_fd_storage::io_uring_fd_storage(
     io_uring_sqring_wait_func_t io_uring_sqring_wait_func,
     io_uring_peek_cqe_func_t io_uring_peek_cqe_func) :
     fd_storage_base(fd, std::move(reopen_path)),
+    ring_(queue_size),
     buffer_capacity_(buffer_capacity),
     batch_size_(batch_size),
     io_uring_submit_func_(io_uring_submit_func),
@@ -4392,23 +4513,17 @@ inline xtr::io_uring_fd_storage::io_uring_fd_storage(
     if (batch_size == 0)
         detail::throw_invalid_argument("batch_size cannot be zero");
 
-    const int flags =
-#if XTR_IO_URING_POLL
-        IORING_SETUP_SQPOLL;
-#else
-        0;
-#endif
+    if (batch_size > queue_size)
+        detail::throw_invalid_argument("batch_size cannot exceed queue size");
 
-    if (const int errnum =
-            ::io_uring_queue_init(unsigned(queue_size), &ring_, flags))
-    {
-        detail::throw_system_error_fmt(
-            -errnum,
-            "xtr::io_uring_fd_storage::io_uring_fd_storage: "
-            "io_uring_queue_init failed");
-    }
+    if (!detail::is_seekable(fd))
+        detail::throw_invalid_argument("File descriptor is not seekable");
+
+    if (detail::is_append(fd))
+        detail::throw_invalid_argument("File descriptor has O_APPEND set");
 
     allocate_buffers(queue_size);
+    set_offset();
 }
 
 inline xtr::io_uring_fd_storage::io_uring_fd_storage(
@@ -4433,18 +4548,18 @@ inline xtr::io_uring_fd_storage::io_uring_fd_storage(
 
 inline xtr::io_uring_fd_storage::~io_uring_fd_storage()
 {
-    flush();
     sync();
-    ::io_uring_queue_exit(&ring_);
 }
 
 inline void xtr::io_uring_fd_storage::flush()
 {
-    io_uring_submit_func_(&ring_);
+    io_uring_submit_func_(ring_.get());
+    batch_index_ = 0;
 }
 
 inline void xtr::io_uring_fd_storage::sync() noexcept
 {
+    flush();
     while (pending_cqe_count_ > 0)
         wait_for_one_cqe();
     fd_storage_base::sync();
@@ -4482,22 +4597,46 @@ inline void xtr::io_uring_fd_storage::submit_buffer(char* data, std::size_t size
 
     ::io_uring_sqe_set_data(sqe, buf);
 
+    sqe->flags |= IOSQE_IO_HARDLINK;
+
+    if (batch_index_ % batch_size_ == 0)
+        sqe->flags |= IOSQE_IO_DRAIN;
+
     offset_ += size;
     ++pending_cqe_count_;
 
     if (++batch_index_ % batch_size_ == 0)
-        io_uring_submit_func_(&ring_);
+        io_uring_submit_func_(ring_.get());
 }
 
-inline void xtr::io_uring_fd_storage::replace_fd(int newfd) noexcept
+inline void xtr::io_uring_fd_storage::replace_fd(detail::file_descriptor fd) noexcept
 {
-    io_uring_sqe* sqe = get_sqe();
-    ::io_uring_prep_close(sqe, fd_.release());
-    sqe->flags |= IOSQE_IO_DRAIN;
-    ++pending_cqe_count_;
-    io_uring_submit_func_(&ring_);
+    flush();
 
-    fd_storage_base::replace_fd(newfd);
+    while (pending_cqe_count_ > 0)
+        wait_for_one_cqe();
+
+    fd_storage_base::replace_fd(std::move(fd));
+    set_offset();
+}
+
+inline void xtr::io_uring_fd_storage::set_offset() noexcept
+{
+    assert(fd_);
+    const ::off_t end = ::lseek(fd_.get(), 0, SEEK_CUR);
+    if (end == -1) [[unlikely]]
+    {
+        (void)std::fprintf(
+            stderr,
+            "xtr::io_uring_fd_storage::set_offset: lseek on \"%s\" (fd %d) "
+            "failed: %s\n",
+            reopen_path_.c_str(),
+            fd_.get(),
+            std::strerror(errno));
+        offset_ = 0;
+        return;
+    }
+    offset_ = std::size_t(end);
 }
 
 inline void xtr::io_uring_fd_storage::allocate_buffers(std::size_t queue_size)
@@ -4516,7 +4655,7 @@ inline void xtr::io_uring_fd_storage::allocate_buffers(std::size_t queue_size)
     {
         std::byte* storage =
             buffer_storage_.get() + buffer::size(buffer_capacity_) * i;
-        buffer* buf = ::new (storage) buffer;
+        auto* buf = ::new (storage) buffer;
         buf->index_ = int(i);
         iov.push_back({buf->data_, buffer_capacity_});
         *next = buf;
@@ -4527,7 +4666,7 @@ inline void xtr::io_uring_fd_storage::allocate_buffers(std::size_t queue_size)
     assert(free_list_ != nullptr);
 
     if (const int errnum =
-            ::io_uring_register_buffers(&ring_, &iov[0], unsigned(iov.size())))
+            ::io_uring_register_buffers(ring_.get(), &iov[0], unsigned(iov.size())))
     {
         detail::throw_system_error_fmt(
             -errnum,
@@ -4540,12 +4679,12 @@ inline io_uring_sqe* xtr::io_uring_fd_storage::get_sqe()
 {
     io_uring_sqe* sqe;
 
-    while ((sqe = io_uring_get_sqe_func_(&ring_)) == nullptr)
+    while ((sqe = io_uring_get_sqe_func_(ring_.get())) == nullptr)
     {
 #if XTR_IO_URING_POLL
-        io_uring_sqring_wait_func_(&ring_);
+        io_uring_sqring_wait_func_(ring_.get());
 #else
-        wait_for_one_cqe();
+        flush();
 #endif
     }
 
@@ -4561,10 +4700,13 @@ inline void xtr::io_uring_fd_storage::wait_for_one_cqe()
 
 retry:
 #if XTR_IO_URING_POLL
-    while ((errnum = io_uring_peek_cqe_func_(&ring_, &cqe)) == -EAGAIN)
+    while ((errnum = io_uring_peek_cqe_func_(ring_.get(), &cqe)) == -EAGAIN)
         ;
 #else
-    errnum = io_uring_wait_cqe_func_(&ring_, &cqe);
+    do
+    {
+        errnum = io_uring_wait_cqe_func_(ring_.get(), &cqe);
+    } while (errnum == -EINTR);
 #endif
 
     if (errnum != 0) [[unlikely]]
@@ -4587,20 +4729,7 @@ retry:
         static_cast<buffer*>(::io_uring_cqe_get_data(cqe)),
         std::move(deleter));
 
-    ::io_uring_cqe_seen(&ring_, cqe);
-
-    if (!buf) // close operation queued by replace_fd()
-    {
-        if (res < 0)
-        {
-            (void)std::fprintf(
-                stderr,
-                "xtr::io_uring_fd_storage::wait_for_one_cqe: "
-                "Error: close(2) failed during reopen: %s\n",
-                std::strerror(-res));
-        }
-        return;
-    }
+    ::io_uring_cqe_seen(ring_.get(), cqe);
 
     if (res == -EAGAIN) [[unlikely]]
     {
@@ -4640,11 +4769,7 @@ inline void xtr::io_uring_fd_storage::resubmit_buffer(buffer* buf, unsigned nwri
     buf->offset_ += nwritten;
     buf->file_offset_ += nwritten;
 
-    assert(io_uring_sq_space_left(&ring_) >= 1);
-
-    io_uring_sqe* sqe = io_uring_get_sqe_func_(&ring_);
-
-    assert(sqe != nullptr);
+    io_uring_sqe* sqe = get_sqe();
 
     ::io_uring_prep_write_fixed(
         sqe,
@@ -4658,7 +4783,7 @@ inline void xtr::io_uring_fd_storage::resubmit_buffer(buffer* buf, unsigned nwri
 
     ++pending_cqe_count_;
 
-    io_uring_submit_func_(&ring_);
+    io_uring_submit_func_(ring_.get());
 }
 
 inline void xtr::io_uring_fd_storage::free_buffer(buffer* buf)
@@ -4985,6 +5110,43 @@ inline xtr::detail::mirrored_memory_mapping::~mirrored_memory_mapping()
     }
 }
 
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+inline xtr::detail::file_descriptor xtr::detail::open_at_end(const char* path) noexcept
+{
+    const int fd = XTR_TEMP_FAILURE_RETRY(
+        ::open(
+            path,
+            O_CREAT | O_WRONLY,
+            S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH));
+
+    if (fd != -1)
+        (void)::lseek(fd, 0, SEEK_END);
+
+    return file_descriptor(fd);
+}
+
+inline bool xtr::detail::is_seekable(int fd) noexcept
+{
+    return ::lseek(fd, 0, SEEK_CUR) != -1;
+}
+
+inline bool xtr::detail::is_append(int fd) noexcept
+{
+    const int flags = ::fcntl(fd, F_GETFL);
+    return flags != -1 && (flags & O_APPEND);
+}
+
+inline bool xtr::detail::set_append(int fd) noexcept
+{
+    const int flags = ::fcntl(fd, F_GETFL);
+    if (flags == -1)
+        return false;
+    return ::fcntl(fd, F_SETFL, flags | O_APPEND) == 0;
+}
+
 #include <cerrno>
 
 #include <unistd.h>
@@ -4998,6 +5160,8 @@ inline std::size_t xtr::detail::align_to_page_size(std::size_t length)
 }
 
 #include <cerrno>
+#include <cstdio>
+#include <cstring>
 #include <memory>
 #include <utility>
 
@@ -5014,6 +5178,21 @@ inline xtr::posix_fd_storage::posix_fd_storage(
 inline std::span<char> xtr::posix_fd_storage::allocate_buffer()
 {
     return {buf_.get(), buffer_capacity_};
+}
+
+inline void xtr::posix_fd_storage::replace_fd(detail::file_descriptor fd) noexcept
+{
+    if (!detail::set_append(fd.get()))
+    {
+        (void)std::fprintf(
+            stderr,
+            "xtr::posix_fd_storage::replace_fd: Failed to set O_APPEND on "
+            "\"%s\" (fd %d): %s\n",
+            reopen_path_.c_str(),
+            fd.get(),
+            std::strerror(errno));
+    }
+    fd_storage_base::replace_fd(std::move(fd));
 }
 
 inline void xtr::posix_fd_storage::submit_buffer(char* buf, std::size_t size)

--- a/single_include/xtr/logger.hpp
+++ b/single_include/xtr/logger.hpp
@@ -851,11 +851,7 @@ public:
 
     void reduce_readable(size_type nbytes) noexcept
     {
-
-        nread_plus_capacity_.store(
-            nread_plus_capacity_.load(std::memory_order_relaxed) + nbytes,
-            std::memory_order_release);
-
+        nread_plus_capacity_.fetch_add(nbytes, std::memory_order_release);
 #if !defined(XTR_THREAD_SANITIZER_ENABLED)
         assert(nread_plus_capacity_.load() - nwritten_.load() <= capacity());
 #endif
@@ -3415,7 +3411,8 @@ public:
      * to @ref logger::logger then this function must be called in order to
      * process messages written to the logger. Users may call this function from
      * a thread of their choosing and may interleave calls with other background
-     * tasks that their program needs to perform.
+     * tasks that their program needs to perform. Once it has been called from
+     * a given thread it must continue to be called from the same thread.
      *
      * For best results when interleaving with other tasks ensure that io_uring
      * mode is enabled (so that I/O will be performed asynchronously leaving
@@ -4115,7 +4112,11 @@ inline bool xtr::detail::consumer::run_once(pump_io_stats* stats) noexcept
     }
 
     if (sinks_.empty())
+    {
+        buf.flush();
+        buf.storage().sync();
         destruct_latch_.count_down();
+    }
 
     if (stats != nullptr)
         stats->n_events = n_events;
@@ -4731,7 +4732,7 @@ retry:
 
     ::io_uring_cqe_seen(ring_.get(), cqe);
 
-    if (res == -EAGAIN) [[unlikely]]
+    if (res == -EAGAIN || res == -ECANCELED) [[unlikely]]
     {
         resubmit_buffer(buf.release(), 0);
         goto retry;

--- a/src/consumer.cpp
+++ b/src/consumer.cpp
@@ -149,10 +149,17 @@ bool xtr::detail::consumer::run_once(pump_io_stats* stats) noexcept
         flush_count_ = sinks_.size();
     }
 
-    // Signal to ~consumer that it can safely destruct (run_once will not be
-    // called again after it returns false).
     if (sinks_.empty())
+    {
+        // Sync the storage so that no io_uring submissions are pending when
+        // this thread exits---the kernel may cancel requests owned by exiting
+        // threads.
+        buf.flush();
+        buf.storage().sync();
+        // Signal to ~consumer that it can safely destruct (run_once will not
+        // be called again after it returns false).
         destruct_latch_.count_down();
+    }
 
     if (stats != nullptr)
         stats->n_events = n_events;

--- a/src/fd_storage.cpp
+++ b/src/fd_storage.cpp
@@ -20,11 +20,10 @@
 
 #include "xtr/io/fd_storage.hpp"
 #include "xtr/config.hpp"
+#include "xtr/detail/throw.hpp"
+#include "xtr/io/detail/open.hpp"
 #include "xtr/io/io_uring_fd_storage.hpp"
 #include "xtr/io/posix_fd_storage.hpp"
-
-#include "xtr/detail/retry.hpp"
-#include "xtr/detail/throw.hpp"
 
 #include <fmt/compile.h>
 #include <fmt/format.h>
@@ -44,18 +43,25 @@ namespace xtr::detail
     bool is_seekable(int fd)
     {
         struct ::stat st;
-        return ::fstat(fd, &st) == 0 && S_ISREG(st.st_mode);
+        if (::fstat(fd, &st) != 0)
+            throw_system_error_fmt(errno, "fstat on fd %d failed", fd);
+        return S_ISREG(st.st_mode);
+    }
+
+    XTR_FUNC
+    bool is_append(int fd)
+    {
+        const int flags = ::fcntl(fd, F_GETFL);
+        if (flags == -1)
+            throw_system_error_fmt(errno, "fcntl on fd %d failed", fd);
+        return flags & O_APPEND;
     }
 }
 
 XTR_FUNC
 xtr::storage_interface_ptr xtr::make_fd_storage(const char* path)
 {
-    const int fd = XTR_TEMP_FAILURE_RETRY(
-        ::open(
-            path,
-            O_CREAT | O_APPEND | O_WRONLY,
-            S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH));
+    const int fd = detail::open_at_end(path);
 
     if (fd == -1)
         detail::throw_system_error_fmt(errno, "Failed to open `%s'", path);
@@ -75,10 +81,13 @@ xtr::storage_interface_ptr xtr::make_fd_storage(int fd, std::string reopen_path)
 #if XTR_USE_IO_URING
     errno = 0;
     (void)syscall(__NR_io_uring_setup, 0, nullptr);
+    const bool has_io_uring = errno != ENOSYS;
 
-    // io_uring is disabled on non-seekable files as the io_uring backend
-    // relies on writing to specific file offsets.
-    if (detail::is_seekable(fd) && errno != ENOSYS)
+    // io_uring is disabled on non-seekable files or file descriptors with
+    // O_APPEND set because the io_uring backend relies on writing to specific
+    // file offsets. Note that on Linux if a file is opened with O_APPEND then
+    // file offsets passed to pwrite and io_uring are ignored.
+    if (has_io_uring && detail::is_seekable(fd) && !detail::is_append(fd))
     {
 #if __cpp_exceptions
         try

--- a/src/fd_storage.cpp
+++ b/src/fd_storage.cpp
@@ -20,6 +20,7 @@
 
 #include "xtr/io/fd_storage.hpp"
 #include "xtr/config.hpp"
+#include "xtr/detail/file_descriptor.hpp"
 #include "xtr/detail/throw.hpp"
 #include "xtr/io/detail/open.hpp"
 #include "xtr/io/io_uring_fd_storage.hpp"
@@ -30,43 +31,71 @@
 
 #include <cerrno>
 #include <memory>
+#include <string_view>
 #include <utility>
 
-#include <fcntl.h>
-#include <sys/stat.h>
+#include <sys/mman.h>
 #include <sys/syscall.h>
 #include <unistd.h>
 
 namespace xtr::detail
 {
+#if XTR_USE_IO_URING
+    // This writes a single buffer using the io_uring storage backend and
+    // checks it is written correctly. This is done to catch issues with
+    // missing features on older kernels (like IOSQE_IO_HARDLINK).
     XTR_FUNC
-    bool is_seekable(int fd)
+    bool is_io_uring_working()
     {
-        struct ::stat st;
-        if (::fstat(fd, &st) != 0)
-            throw_system_error_fmt(errno, "fstat on fd %d failed", fd);
-        return S_ISREG(st.st_mode);
-    }
+        constexpr std::string_view magic = "io_uring is working";
+        constexpr std::size_t buf_capacity = 32;
 
-    XTR_FUNC
-    bool is_append(int fd)
-    {
-        const int flags = ::fcntl(fd, F_GETFL);
-        if (flags == -1)
-            throw_system_error_fmt(errno, "fcntl on fd %d failed", fd);
-        return flags & O_APPEND;
+        file_descriptor memfd(::memfd_create("xtr_health_check", MFD_CLOEXEC));
+
+        if (!memfd)
+            return false;
+
+#if __cpp_exceptions
+        try
+#endif
+        {
+            io_uring_fd_storage storage(
+                memfd.get(),
+                null_reopen_path,
+                buf_capacity,
+                /* queue_size= */ 2,
+                /* batch_size= */ 1);
+            const std::span<char> span = storage.allocate_buffer();
+            magic.copy(span.data(), magic.size());
+            storage.submit_buffer(span.data(), magic.size());
+            storage.sync();
+        }
+#if __cpp_exceptions
+        catch (const std::exception&)
+        {
+            return false;
+        }
+#endif
+
+        char buf[buf_capacity];
+        const ::ssize_t nread = ::pread(memfd.get(), buf, sizeof(buf), 0);
+        return nread >= 0 && std::string_view(buf, std::size_t(nread)) == magic;
     }
+#endif
+
+    storage_interface_ptr make_fd_storage(
+        int fd, std::string reopen_path, bool fd_created);
 }
 
 XTR_FUNC
 xtr::storage_interface_ptr xtr::make_fd_storage(const char* path)
 {
-    const int fd = detail::open_at_end(path);
+    const auto fd = detail::open_at_end(path);
 
-    if (fd == -1)
+    if (!fd)
         detail::throw_system_error_fmt(errno, "Failed to open `%s'", path);
 
-    return make_fd_storage(fd, path);
+    return detail::make_fd_storage(fd.get(), path, /* fd_created= */ true);
 }
 
 XTR_FUNC
@@ -78,6 +107,13 @@ xtr::storage_interface_ptr xtr::make_fd_storage(FILE* fp, std::string reopen_pat
 XTR_FUNC
 xtr::storage_interface_ptr xtr::make_fd_storage(int fd, std::string reopen_path)
 {
+    return detail::make_fd_storage(fd, std::move(reopen_path), /* fd_created= */ false);
+}
+
+XTR_FUNC
+xtr::storage_interface_ptr xtr::detail::make_fd_storage(
+    int fd, std::string reopen_path, bool fd_created)
+{
 #if XTR_USE_IO_URING
     errno = 0;
     (void)syscall(__NR_io_uring_setup, 0, nullptr);
@@ -87,7 +123,8 @@ xtr::storage_interface_ptr xtr::make_fd_storage(int fd, std::string reopen_path)
     // O_APPEND set because the io_uring backend relies on writing to specific
     // file offsets. Note that on Linux if a file is opened with O_APPEND then
     // file offsets passed to pwrite and io_uring are ignored.
-    if (has_io_uring && detail::is_seekable(fd) && !detail::is_append(fd))
+    if (has_io_uring && detail::is_seekable(fd) && !detail::is_append(fd) &&
+        detail::is_io_uring_working())
     {
 #if __cpp_exceptions
         try
@@ -108,5 +145,20 @@ xtr::storage_interface_ptr xtr::make_fd_storage(int fd, std::string reopen_path)
 #endif
     }
 #endif
+
+    // If we opened the file descriptor, then set O_APPEND. The O_APPEND flag isn't
+    // set at creation time because the io_uring backend needs it to be off. Setting
+    // it on the POSIX backend is done to preserve existing behaviour---if it is
+    // not set then truncating the file (e.g. via logrotate in copytruncate mode)
+    // would result in a hole being created instead of writing from offset zero.
+    // For user supplied file descriptors we do not modify file flags.
+    if (fd_created && !detail::set_append(fd))
+    {
+        detail::throw_system_error_fmt(
+            errno,
+            "Failed to set O_APPEND on `%s'",
+            reopen_path.c_str());
+    }
+
     return std::make_unique<posix_fd_storage>(fd, std::move(reopen_path));
 }

--- a/src/fd_storage_base.cpp
+++ b/src/fd_storage_base.cpp
@@ -19,6 +19,7 @@
 // SOFTWARE.
 
 #include "xtr/io/detail/fd_storage_base.hpp"
+#include "xtr/io/detail/open.hpp"
 #include "xtr/detail/retry.hpp"
 #include "xtr/detail/throw.hpp"
 
@@ -57,11 +58,7 @@ int xtr::detail::fd_storage_base::reopen() noexcept
     if (reopen_path_ == null_reopen_path)
         return ENOENT;
 
-    const int newfd = XTR_TEMP_FAILURE_RETRY(
-        ::open(
-            reopen_path_.c_str(),
-            O_CREAT | O_APPEND | O_WRONLY,
-            S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH));
+    const int newfd = detail::open_at_end(reopen_path_.c_str());
 
     if (newfd == -1)
         return errno;

--- a/src/fd_storage_base.cpp
+++ b/src/fd_storage_base.cpp
@@ -58,18 +58,18 @@ int xtr::detail::fd_storage_base::reopen() noexcept
     if (reopen_path_ == null_reopen_path)
         return ENOENT;
 
-    const int newfd = detail::open_at_end(reopen_path_.c_str());
+    auto fd = detail::open_at_end(reopen_path_.c_str());
 
-    if (newfd == -1)
+    if (!fd)
         return errno;
 
-    replace_fd(newfd);
+    replace_fd(std::move(fd));
 
     return 0;
 }
 
 XTR_FUNC
-void xtr::detail::fd_storage_base::replace_fd(int newfd) noexcept
+void xtr::detail::fd_storage_base::replace_fd(file_descriptor fd) noexcept
 {
-    fd_.reset(newfd);
+    fd_ = std::move(fd);
 }

--- a/src/io_uring_fd_storage.cpp
+++ b/src/io_uring_fd_storage.cpp
@@ -81,6 +81,7 @@ xtr::io_uring_fd_storage::io_uring_fd_storage(
     }
 
     allocate_buffers(queue_size);
+    set_offset();
 }
 
 XTR_FUNC
@@ -186,6 +187,8 @@ void xtr::io_uring_fd_storage::submit_buffer(char* data, std::size_t size)
 XTR_FUNC
 void xtr::io_uring_fd_storage::replace_fd(int newfd) noexcept
 {
+    flush();
+
     // Wait for in-flight requests to complete before replacing. This must be
     // done because an in-flight request could fail and be resubmitted---if
     // that happens after the fd is replaced then the request would be
@@ -194,8 +197,14 @@ void xtr::io_uring_fd_storage::replace_fd(int newfd) noexcept
         wait_for_one_cqe();
 
     fd_storage_base::replace_fd(newfd);
+    set_offset();
+}
 
-    const ::off_t end = ::lseek(newfd, 0, SEEK_CUR);
+XTR_FUNC
+void xtr::io_uring_fd_storage::set_offset() noexcept
+{
+    assert(fd_);
+    const ::off_t end = ::lseek(fd_.get(), 0, SEEK_CUR);
     offset_ = std::size_t(end != -1 ? end : 0L);
 }
 

--- a/src/io_uring_fd_storage.cpp
+++ b/src/io_uring_fd_storage.cpp
@@ -32,6 +32,8 @@
 #include <limits>
 #include <vector>
 
+#include <unistd.h>
+
 XTR_FUNC
 xtr::io_uring_fd_storage::io_uring_fd_storage(
     int fd,
@@ -149,9 +151,7 @@ void xtr::io_uring_fd_storage::submit_buffer(char* data, std::size_t size)
 
     io_uring_sqe* sqe = get_sqe();
 
-    // Per https://github.com/axboe/liburing/issues/507#issuecomment-1005869351
-    // using seek offsets is preferred over appending (via passing an offset of
-    // -1).
+    // Use fixed offsets to make resubmitting buffers simple
     ::io_uring_prep_write_fixed(
         sqe,
         fd_.get(),
@@ -161,6 +161,20 @@ void xtr::io_uring_fd_storage::submit_buffer(char* data, std::size_t size)
         buf->index_);
 
     ::io_uring_sqe_set_data(sqe, buf);
+
+    // Hardlink to the next SQE so writes complete in offset order. Without
+    // this, out-of-order completion can briefly leave holes in the file that
+    // confuse tools tailing the log. HARDLINK (not LINK) is used so that a
+    // failed or short write does not cancel subsequent queued writes.
+    sqe->flags |= IOSQE_IO_HARDLINK;
+
+    // First SQE of a batch drains the prior batch before starting. When
+    // combined with inter-batch hardlinking via IOSQE_IO_HARDLINK all buffers
+    // should be written in strict sequential order, with the exception of
+    // resubmitted buffers (which should never happen on a regular disk). If a
+    // buffer is resubmitted there would be a brief hole in the file.
+    if (batch_index_ % batch_size_ == 0)
+        sqe->flags |= IOSQE_IO_DRAIN;
 
     offset_ += size;
     ++pending_cqe_count_;
@@ -172,16 +186,17 @@ void xtr::io_uring_fd_storage::submit_buffer(char* data, std::size_t size)
 XTR_FUNC
 void xtr::io_uring_fd_storage::replace_fd(int newfd) noexcept
 {
-    // As write events might be in-flight, closing the file descriptor must
-    // be queued up behind any pending writes. IOSQE_IO_DRAIN is used to
-    // ensure that all previous writes complete before closing.
-    io_uring_sqe* sqe = get_sqe();
-    ::io_uring_prep_close(sqe, fd_.release());
-    sqe->flags |= IOSQE_IO_DRAIN;
-    ++pending_cqe_count_;
-    io_uring_submit_func_(&ring_);
+    // Wait for in-flight requests to complete before replacing. This must be
+    // done because an in-flight request could fail and be resubmitted---if
+    // that happens after the fd is replaced then the request would be
+    // resubmitted with the wrong fd.
+    while (pending_cqe_count_ > 0)
+        wait_for_one_cqe();
 
     fd_storage_base::replace_fd(newfd);
+
+    const ::off_t end = ::lseek(newfd, 0, SEEK_CUR);
+    offset_ = std::size_t(end != -1 ? end : 0L);
 }
 
 XTR_FUNC
@@ -201,7 +216,7 @@ void xtr::io_uring_fd_storage::allocate_buffers(std::size_t queue_size)
     {
         std::byte* storage =
             buffer_storage_.get() + buffer::size(buffer_capacity_) * i;
-        buffer* buf = ::new (storage) buffer;
+        auto* buf = ::new (storage) buffer;
         buf->index_ = int(i);
         iov.push_back({buf->data_, buffer_capacity_});
         // Push the buffer to the end of free_list_:
@@ -277,22 +292,6 @@ retry:
         std::move(deleter));
 
     ::io_uring_cqe_seen(&ring_, cqe);
-
-    if (!buf) // close operation queued by replace_fd()
-    {
-        // If close(2) failed, there is nothing to be done except report an
-        // error, as the state of the file descriptor is ambiguous (according
-        // to POSIX).
-        if (res < 0)
-        {
-            (void)std::fprintf(
-                stderr,
-                "xtr::io_uring_fd_storage::wait_for_one_cqe: "
-                "Error: close(2) failed during reopen: %s\n",
-                std::strerror(-res));
-        }
-        return;
-    }
 
     if (res == -EAGAIN) [[unlikely]]
     {

--- a/src/io_uring_fd_storage.cpp
+++ b/src/io_uring_fd_storage.cpp
@@ -108,7 +108,6 @@ xtr::io_uring_fd_storage::io_uring_fd_storage(
 XTR_FUNC
 xtr::io_uring_fd_storage::~io_uring_fd_storage()
 {
-    flush();
     sync();
     ::io_uring_queue_exit(&ring_);
 }
@@ -123,6 +122,7 @@ void xtr::io_uring_fd_storage::flush()
 XTR_FUNC
 void xtr::io_uring_fd_storage::sync() noexcept
 {
+    flush();
     while (pending_cqe_count_ > 0)
         wait_for_one_cqe();
     fd_storage_base::sync();
@@ -205,7 +205,19 @@ void xtr::io_uring_fd_storage::set_offset() noexcept
 {
     assert(fd_);
     const ::off_t end = ::lseek(fd_.get(), 0, SEEK_CUR);
-    offset_ = std::size_t(end != -1 ? end : 0L);
+    if (end == -1) [[unlikely]]
+    {
+        (void)std::fprintf(
+            stderr,
+            "xtr::io_uring_fd_storage::set_offset: lseek on \"%s\" (fd %d) "
+            "failed: %s\n",
+            reopen_path_.c_str(),
+            fd_.get(),
+            std::strerror(errno));
+        offset_ = 0;
+        return;
+    }
+    offset_ = std::size_t(end);
 }
 
 XTR_FUNC

--- a/src/io_uring_fd_storage.cpp
+++ b/src/io_uring_fd_storage.cpp
@@ -22,6 +22,7 @@
 
 #if XTR_USE_IO_URING
 #include "xtr/detail/throw.hpp"
+#include "xtr/io/detail/open.hpp"
 #include "xtr/io/io_uring_fd_storage.hpp"
 
 #include <liburing.h>
@@ -33,6 +34,37 @@
 #include <vector>
 
 #include <unistd.h>
+
+XTR_FUNC
+xtr::detail::unique_io_uring::unique_io_uring(std::size_t queue_size)
+{
+    const int flags =
+#if XTR_IO_URING_POLL
+        IORING_SETUP_SQPOLL;
+#else
+        0;
+#endif
+
+    if (const int errnum =
+            ::io_uring_queue_init(unsigned(queue_size), &ring_, flags))
+    {
+        throw_system_error_fmt(
+            -errnum,
+            "xtr::detail::unique_io_uring: io_uring_queue_init failed");
+    }
+}
+
+XTR_FUNC
+xtr::detail::unique_io_uring::~unique_io_uring()
+{
+    ::io_uring_queue_exit(&ring_);
+}
+
+XTR_FUNC
+io_uring* xtr::detail::unique_io_uring::get() noexcept
+{
+    return &ring_;
+}
 
 XTR_FUNC
 xtr::io_uring_fd_storage::io_uring_fd_storage(
@@ -47,6 +79,7 @@ xtr::io_uring_fd_storage::io_uring_fd_storage(
     io_uring_sqring_wait_func_t io_uring_sqring_wait_func,
     io_uring_peek_cqe_func_t io_uring_peek_cqe_func) :
     fd_storage_base(fd, std::move(reopen_path)),
+    ring_(queue_size),
     buffer_capacity_(buffer_capacity),
     batch_size_(batch_size),
     io_uring_submit_func_(io_uring_submit_func),
@@ -64,21 +97,17 @@ xtr::io_uring_fd_storage::io_uring_fd_storage(
     if (batch_size == 0)
         detail::throw_invalid_argument("batch_size cannot be zero");
 
-    const int flags =
-#if XTR_IO_URING_POLL
-        IORING_SETUP_SQPOLL;
-#else
-        0;
-#endif
+    if (batch_size > queue_size)
+        detail::throw_invalid_argument("batch_size cannot exceed queue size");
 
-    if (const int errnum =
-            ::io_uring_queue_init(unsigned(queue_size), &ring_, flags))
-    {
-        detail::throw_system_error_fmt(
-            -errnum,
-            "xtr::io_uring_fd_storage::io_uring_fd_storage: "
-            "io_uring_queue_init failed");
-    }
+    if (!detail::is_seekable(fd))
+        detail::throw_invalid_argument("File descriptor is not seekable");
+
+    // On Linux if a file is opened with O_APPEND then the file offsets
+    // passed to io_uring are ignored, breaking buffer resubmission and
+    // file offset accounting.
+    if (detail::is_append(fd))
+        detail::throw_invalid_argument("File descriptor has O_APPEND set");
 
     allocate_buffers(queue_size);
     set_offset();
@@ -109,14 +138,16 @@ XTR_FUNC
 xtr::io_uring_fd_storage::~io_uring_fd_storage()
 {
     sync();
-    ::io_uring_queue_exit(&ring_);
 }
 
 XTR_FUNC
 void xtr::io_uring_fd_storage::flush()
 {
     // SQEs may have been prepared but not submitted, due to batching
-    io_uring_submit_func_(&ring_);
+    io_uring_submit_func_(ring_.get());
+    // Reset batch_index_ so that the next batch sets IOSQE_IO_DRAIN on the
+    // first SQE
+    batch_index_ = 0;
 }
 
 XTR_FUNC
@@ -170,7 +201,7 @@ void xtr::io_uring_fd_storage::submit_buffer(char* data, std::size_t size)
     sqe->flags |= IOSQE_IO_HARDLINK;
 
     // First SQE of a batch drains the prior batch before starting. When
-    // combined with inter-batch hardlinking via IOSQE_IO_HARDLINK all buffers
+    // combined with intra-batch hardlinking via IOSQE_IO_HARDLINK all buffers
     // should be written in strict sequential order, with the exception of
     // resubmitted buffers (which should never happen on a regular disk). If a
     // buffer is resubmitted there would be a brief hole in the file.
@@ -181,11 +212,11 @@ void xtr::io_uring_fd_storage::submit_buffer(char* data, std::size_t size)
     ++pending_cqe_count_;
 
     if (++batch_index_ % batch_size_ == 0)
-        io_uring_submit_func_(&ring_);
+        io_uring_submit_func_(ring_.get());
 }
 
 XTR_FUNC
-void xtr::io_uring_fd_storage::replace_fd(int newfd) noexcept
+void xtr::io_uring_fd_storage::replace_fd(detail::file_descriptor fd) noexcept
 {
     flush();
 
@@ -196,7 +227,7 @@ void xtr::io_uring_fd_storage::replace_fd(int newfd) noexcept
     while (pending_cqe_count_ > 0)
         wait_for_one_cqe();
 
-    fd_storage_base::replace_fd(newfd);
+    fd_storage_base::replace_fd(std::move(fd));
     set_offset();
 }
 
@@ -249,7 +280,7 @@ void xtr::io_uring_fd_storage::allocate_buffers(std::size_t queue_size)
     assert(free_list_ != nullptr);
 
     if (const int errnum =
-            ::io_uring_register_buffers(&ring_, &iov[0], unsigned(iov.size())))
+            ::io_uring_register_buffers(ring_.get(), &iov[0], unsigned(iov.size())))
     {
         detail::throw_system_error_fmt(
             -errnum,
@@ -263,13 +294,14 @@ io_uring_sqe* xtr::io_uring_fd_storage::get_sqe()
 {
     io_uring_sqe* sqe;
 
-    while ((sqe = io_uring_get_sqe_func_(&ring_)) == nullptr)
+    while ((sqe = io_uring_get_sqe_func_(ring_.get())) == nullptr)
     {
 #if XTR_IO_URING_POLL
-        io_uring_sqring_wait_func_(&ring_);
+        io_uring_sqring_wait_func_(ring_.get());
 #else
-        // Waiting for a CQE seems to be the only option here
-        wait_for_one_cqe();
+        // This should never happen, if it does calling flush is all we can do
+        // to free up SQEs.
+        flush();
 #endif
     }
 
@@ -286,10 +318,13 @@ void xtr::io_uring_fd_storage::wait_for_one_cqe()
 
 retry:
 #if XTR_IO_URING_POLL
-    while ((errnum = io_uring_peek_cqe_func_(&ring_, &cqe)) == -EAGAIN)
+    while ((errnum = io_uring_peek_cqe_func_(ring_.get(), &cqe)) == -EAGAIN)
         ;
 #else
-    errnum = io_uring_wait_cqe_func_(&ring_, &cqe);
+    do
+    {
+        errnum = io_uring_wait_cqe_func_(ring_.get(), &cqe);
+    } while (errnum == -EINTR);
 #endif
 
     if (errnum != 0) [[unlikely]]
@@ -312,7 +347,7 @@ retry:
         static_cast<buffer*>(::io_uring_cqe_get_data(cqe)),
         std::move(deleter));
 
-    ::io_uring_cqe_seen(&ring_, cqe);
+    ::io_uring_cqe_seen(ring_.get(), cqe);
 
     if (res == -EAGAIN) [[unlikely]]
     {
@@ -353,15 +388,7 @@ void xtr::io_uring_fd_storage::resubmit_buffer(buffer* buf, unsigned nwritten)
     buf->offset_ += nwritten;
     buf->file_offset_ += nwritten;
 
-    assert(io_uring_sq_space_left(&ring_) >= 1);
-
-    // Don't call get_sqe() as this function is only called from
-    // wait_for_one_cqe, so space in the submission queue must be available (and
-    // if this is incorrect, calling get_sqe() might have problems due to it
-    // calling wait_for_one_cqe).
-    io_uring_sqe* sqe = io_uring_get_sqe_func_(&ring_);
-
-    assert(sqe != nullptr);
+    io_uring_sqe* sqe = get_sqe();
 
     ::io_uring_prep_write_fixed(
         sqe,
@@ -375,7 +402,7 @@ void xtr::io_uring_fd_storage::resubmit_buffer(buffer* buf, unsigned nwritten)
 
     ++pending_cqe_count_;
 
-    io_uring_submit_func_(&ring_);
+    io_uring_submit_func_(ring_.get());
 }
 
 XTR_FUNC

--- a/src/io_uring_fd_storage.cpp
+++ b/src/io_uring_fd_storage.cpp
@@ -349,7 +349,10 @@ retry:
 
     ::io_uring_cqe_seen(ring_.get(), cqe);
 
-    if (res == -EAGAIN) [[unlikely]]
+    // ECANCELED can occur if the thread that submitted the request exited
+    // before the request completed, which should only happen if pump_io is
+    // used and the user thread is restarted.
+    if (res == -EAGAIN || res == -ECANCELED) [[unlikely]]
     {
         resubmit_buffer(buf.release(), 0);
         goto retry;

--- a/src/open.cpp
+++ b/src/open.cpp
@@ -1,0 +1,45 @@
+// Copyright 2026 Chris E. Holloway
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "xtr/io/detail/open.hpp"
+#include "xtr/detail/retry.hpp"
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+XTR_FUNC
+int xtr::detail::open_at_end(const char* path)
+{
+    // O_APPEND is not used because io_uring_fd_storage relies on writing
+    // buffers to specific offsets---if O_APPEND is used then the offsets
+    // would be ignored.
+    const int fd = XTR_TEMP_FAILURE_RETRY(
+        ::open(
+            path,
+            O_CREAT | O_WRONLY,
+            S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH));
+
+    // Seek to retain O_APPEND open behaviour
+    if (fd != -1)
+        (void)::lseek(fd, 0, SEEK_END);
+
+    return fd;
+}

--- a/src/open.cpp
+++ b/src/open.cpp
@@ -26,7 +26,7 @@
 #include <unistd.h>
 
 XTR_FUNC
-int xtr::detail::open_at_end(const char* path)
+xtr::detail::file_descriptor xtr::detail::open_at_end(const char* path) noexcept
 {
     // O_APPEND is not used because io_uring_fd_storage relies on writing
     // buffers to specific offsets---if O_APPEND is used then the offsets
@@ -41,5 +41,27 @@ int xtr::detail::open_at_end(const char* path)
     if (fd != -1)
         (void)::lseek(fd, 0, SEEK_END);
 
-    return fd;
+    return file_descriptor(fd);
+}
+
+XTR_FUNC
+bool xtr::detail::is_seekable(int fd) noexcept
+{
+    return ::lseek(fd, 0, SEEK_CUR) != -1;
+}
+
+XTR_FUNC
+bool xtr::detail::is_append(int fd) noexcept
+{
+    const int flags = ::fcntl(fd, F_GETFL);
+    return flags != -1 && (flags & O_APPEND);
+}
+
+XTR_FUNC
+bool xtr::detail::set_append(int fd) noexcept
+{
+    const int flags = ::fcntl(fd, F_GETFL);
+    if (flags == -1)
+        return false;
+    return ::fcntl(fd, F_SETFL, flags | O_APPEND) == 0;
 }

--- a/src/posix_fd_storage.cpp
+++ b/src/posix_fd_storage.cpp
@@ -21,8 +21,11 @@
 #include "xtr/io/posix_fd_storage.hpp"
 #include "xtr/detail/retry.hpp"
 #include "xtr/detail/throw.hpp"
+#include "xtr/io/detail/open.hpp"
 
 #include <cerrno>
+#include <cstdio>
+#include <cstring>
 #include <memory>
 #include <utility>
 
@@ -41,6 +44,24 @@ XTR_FUNC
 std::span<char> xtr::posix_fd_storage::allocate_buffer()
 {
     return {buf_.get(), buffer_capacity_};
+}
+
+XTR_FUNC
+void xtr::posix_fd_storage::replace_fd(detail::file_descriptor fd) noexcept
+{
+    // File descriptors passed to replace_fd are created by reopen() so may
+    // be modified. O_APPEND is set so that copy-truncate log rotation works.
+    if (!detail::set_append(fd.get()))
+    {
+        (void)std::fprintf(
+            stderr,
+            "xtr::posix_fd_storage::replace_fd: Failed to set O_APPEND on "
+            "\"%s\" (fd %d): %s\n",
+            reopen_path_.c_str(),
+            fd.get(),
+            std::strerror(errno));
+    }
+    fd_storage_base::replace_fd(std::move(fd));
 }
 
 XTR_FUNC

--- a/test/fd_storage.cpp
+++ b/test/fd_storage.cpp
@@ -449,4 +449,53 @@ TEST_CASE_METHOD(fixture, "write error test", "[fd_storage]")
     storage_->submit_buffer(span.data(), span.size());
     flush_and_sync();
 }
+
+TEST_CASE_METHOD(fixture, "reopen resets file offset", "[fd_storage]")
+{
+    {
+        const auto span = storage_->allocate_buffer();
+        storage_->submit_buffer(span.data(), span.size());
+    }
+    flush_and_sync();
+
+    REQUIRE(::unlink(tmp_.path_.c_str()) == 0);
+    REQUIRE(storage_->reopen() == 0);
+
+    {
+        const auto span = storage_->allocate_buffer();
+        storage_->submit_buffer(span.data(), span.size());
+    }
+    flush_and_sync();
+
+    struct stat st{};
+    REQUIRE(::stat(tmp_.path_.c_str(), &st) == 0);
+    REQUIRE(
+        st.st_size == ::off_t(xtr::io_uring_fd_storage::default_buffer_capacity));
+}
+
+TEST_CASE_METHOD(fixture, "reopen on same file appends to end", "[fd_storage]")
+{
+    {
+        const auto span = storage_->allocate_buffer();
+        storage_->submit_buffer(span.data(), span.size());
+    }
+    flush_and_sync();
+
+    // Reopen with the file still in place. offset_ must be re-seeded from the
+    // new fd's end-of-file so the next write appends rather than overwriting
+    // byte 0.
+    REQUIRE(storage_->reopen() == 0);
+
+    {
+        const auto span = storage_->allocate_buffer();
+        storage_->submit_buffer(span.data(), span.size());
+    }
+    flush_and_sync();
+
+    struct stat st{};
+    REQUIRE(::stat(tmp_.path_.c_str(), &st) == 0);
+    REQUIRE(
+        st.st_size ==
+        ::off_t(xtr::io_uring_fd_storage::default_buffer_capacity * 2));
+}
 #endif

--- a/test/fd_storage.cpp
+++ b/test/fd_storage.cpp
@@ -19,9 +19,9 @@
 // SOFTWARE.
 
 #include "xtr/config.hpp"
-#include "xtr/detail/memory_mapping.hpp"
 
 #if XTR_USE_IO_URING
+#include "xtr/detail/memory_mapping.hpp"
 #include "xtr/io/detail/open.hpp"
 #include "xtr/io/io_uring_fd_storage.hpp"
 
@@ -144,9 +144,7 @@ namespace
             return verify_file_contents(buffer_count, tmp_.path_.c_str());
         }
 
-        bool verify_file_contents(
-            std::size_t buffer_count,
-            const char* path) const
+        bool verify_file_contents(std::size_t buffer_count, const char* path) const
         {
             const std::size_t size = file_size(path);
 
@@ -484,8 +482,7 @@ TEST_CASE_METHOD(fixture, "open existing file appends to end", "[fd_storage]")
 
     storage_.reset();
 
-    xtr::detail::file_descriptor fd(
-        xtr::detail::open_at_end(tmp_.path_.c_str()));
+    xtr::detail::file_descriptor fd(xtr::detail::open_at_end(tmp_.path_.c_str()));
     REQUIRE(fd);
 
     storage_ = std::make_unique<test_fd_storage>(fd.release(), tmp_.path_);

--- a/test/fd_storage.cpp
+++ b/test/fd_storage.cpp
@@ -19,9 +19,10 @@
 // SOFTWARE.
 
 #include "xtr/config.hpp"
+#include "xtr/detail/memory_mapping.hpp"
 
 #if XTR_USE_IO_URING
-#include "xtr/io/fd_storage.hpp"
+#include "xtr/io/detail/open.hpp"
 #include "xtr/io/io_uring_fd_storage.hpp"
 
 #include "temp_file.hpp"
@@ -29,6 +30,7 @@
 #include <catch2/catch.hpp>
 #include <liburing.h>
 
+#include <algorithm>
 #include <cerrno>
 #include <functional>
 #include <iostream>
@@ -117,6 +119,74 @@ namespace
             peek_cqe_hook = io_uring_peek_cqe;
         }
 
+        void send_buffer()
+        {
+            std::span<char> span;
+            XTR_REQUIRE_NOERROR(span = storage_->allocate_buffer());
+            std::ranges::fill(span, fill_++);
+            XTR_REQUIRE_NOERROR(storage_->submit_buffer(span.data(), span.size()));
+        }
+
+        std::size_t buffer_size() const
+        {
+            return xtr::io_uring_fd_storage::default_buffer_capacity;
+        }
+
+        std::size_t file_size(const char* path) const
+        {
+            struct stat st{};
+            REQUIRE(::stat(path, &st) == 0);
+            return std::size_t(st.st_size);
+        }
+
+        bool verify_file_contents(std::size_t buffer_count) const
+        {
+            return verify_file_contents(buffer_count, tmp_.path_.c_str());
+        }
+
+        bool verify_file_contents(
+            std::size_t buffer_count,
+            const char* path) const
+        {
+            const std::size_t size = file_size(path);
+
+            CAPTURE(size);
+            CAPTURE(buffer_count * buffer_size());
+
+            if (buffer_count * buffer_size() != size)
+                return false;
+
+            xtr::detail::file_descriptor fd(path, O_RDONLY);
+            xtr::detail::memory_mapping
+                m(nullptr, size, PROT_READ, MAP_PRIVATE, fd.get());
+
+            auto begin = static_cast<const char*>(m.get());
+            auto end = begin + buffer_size();
+
+            for (std::size_t i = 0; i != buffer_count; ++i)
+            {
+                const auto fill = static_cast<unsigned char>(i);
+                CAPTURE(i);
+                CAPTURE(fill);
+                if (!std::all_of(
+                        begin,
+                        end,
+                        [=](unsigned char c) { return c == fill; }))
+                {
+                    return false;
+                }
+                begin += buffer_size();
+                end += buffer_size();
+            }
+
+            return true;
+        }
+
+        void flush()
+        {
+            storage_->flush();
+        }
+
         void flush_and_sync()
         {
             storage_->flush();
@@ -125,6 +195,7 @@ namespace
 
         temp_file tmp_;
         xtr::storage_interface_ptr storage_;
+        unsigned char fill_ = 0;
     };
 }
 
@@ -142,20 +213,17 @@ TEST_CASE_METHOD(fixture, "write test", "[fd_storage]")
     {
         const int ret = io_uring_wait_cqe(ring, cqe);
         ++cqe_count;
-        REQUIRE((*cqe)->res == xtr::io_uring_fd_storage::default_buffer_capacity);
+        REQUIRE(std::size_t((*cqe)->res) == buffer_size());
         return ret;
     };
 
     for (std::size_t i = 0; i < n; ++i)
-    {
-        std::span<char> span;
-        XTR_REQUIRE_NOERROR(span = storage_->allocate_buffer());
-        XTR_REQUIRE_NOERROR(storage_->submit_buffer(span.data(), span.size()));
-    }
+        send_buffer();
 
     flush_and_sync();
 
     REQUIRE(cqe_count == n);
+    REQUIRE(verify_file_contents(n));
 }
 
 TEST_CASE_METHOD(fixture, "write more than queue size test", "[fd_storage]")
@@ -172,20 +240,17 @@ TEST_CASE_METHOD(fixture, "write more than queue size test", "[fd_storage]")
     {
         const int ret = io_uring_wait_cqe(ring, cqe);
         ++cqe_count;
-        REQUIRE((*cqe)->res == xtr::io_uring_fd_storage::default_buffer_capacity);
+        REQUIRE(std::size_t((*cqe)->res) == buffer_size());
         return ret;
     };
 
     for (std::size_t i = 0; i < n; ++i)
-    {
-        std::span<char> span;
-        XTR_REQUIRE_NOERROR(span = storage_->allocate_buffer());
-        XTR_REQUIRE_NOERROR(storage_->submit_buffer(span.data(), span.size()));
-    }
+        send_buffer();
 
     flush_and_sync();
 
     REQUIRE(cqe_count == n);
+    REQUIRE(verify_file_contents(n));
 }
 
 TEST_CASE_METHOD(fixture, "reopen with writes queued", "[fd_storage]")
@@ -201,10 +266,7 @@ TEST_CASE_METHOD(fixture, "reopen with writes queued", "[fd_storage]")
     // Queue up a large number of writes so that some are (almost) guaranteed
     // to still be in flight when reopen() is called.
     for (std::size_t i = 0; i < xtr::io_uring_fd_storage::default_queue_size; ++i)
-    {
-        const auto span = storage_->allocate_buffer();
-        storage_->submit_buffer(span.data(), span.size());
-    }
+        send_buffer();
 
     io_uring_submit(saved_ring); // release all buffers at once
     REQUIRE(storage_->reopen() == 0);
@@ -214,17 +276,14 @@ TEST_CASE_METHOD(fixture, "reopen with writes queued", "[fd_storage]")
     // (1) CQEs from the first loop are retrieved and checked for errors
     // (2) Writing to the new file is tested
     for (std::size_t i = 0; i < xtr::io_uring_fd_storage::default_queue_size; ++i)
-    {
-        std::span<char> span;
-        XTR_REQUIRE_NOERROR(span = storage_->allocate_buffer());
-        storage_->submit_buffer(span.data(), span.size());
-    }
+        send_buffer();
 }
 
 TEST_CASE_METHOD(fixture, "submission queue full on submit", "[fd_storage]")
 {
-    // First send a close operation so that there is a completion event to wait on
-    REQUIRE(storage_->reopen() == 0);
+    // First send a buffer so that there is a completion event to wait on
+    send_buffer();
+    flush();
 
     // Return null when an SQE is requested (submission queue full) to cause
     // progress to block/spin waiting for a CQE to complete (which implies a
@@ -253,44 +312,7 @@ TEST_CASE_METHOD(fixture, "submission queue full on submit", "[fd_storage]")
     };
 
     // Try to submit a buffer, get_sqe returns null so wait_cqe should be called
-    const auto span = storage_->allocate_buffer();
-    storage_->submit_buffer(span.data(), span.size());
-
-    REQUIRE(wait_cqe_called);
-}
-
-TEST_CASE_METHOD(fixture, "submission queue full on reopen", "[fd_storage]")
-{
-    // First send a close operation so that there is a completion event to wait on
-    REQUIRE(storage_->reopen() == 0);
-
-    // Return null when an SQE is requested to cause progress to block/spin
-    // waiting for a CQE to complete (which implies a SQE is then available)
-    get_sqe_hook = [&](io_uring*) { return nullptr; };
-
-    bool wait_cqe_called = false;
-
-#if XTR_IO_URING_POLL
-    sqring_wait_hook =
-#else
-    wait_cqe_hook =
-#endif
-        [&](auto... args)
-    {
-        if (!wait_cqe_called)
-        {
-            wait_cqe_called = true;
-            get_sqe_hook = io_uring_get_sqe;
-        }
-#if XTR_IO_URING_POLL
-        return io_uring_sqring_wait(args...);
-#else
-        return io_uring_wait_cqe(args...);
-#endif
-    };
-
-    // Try to reopen, get_sqe returns null so wait_cqe should be called
-    REQUIRE(storage_->reopen() == 0);
+    send_buffer();
 
     REQUIRE(wait_cqe_called);
 }
@@ -336,6 +358,8 @@ TEST_CASE_METHOD(fixture, "short write test", "[fd_storage]")
     storage_->submit_buffer(span.data(), span.size());
     flush_and_sync();
 
+    REQUIRE(verify_file_contents(1));
+
     REQUIRE(sqe_count == 2);
     REQUIRE(cqe_count == 2);
     REQUIRE(submit_count == 2);
@@ -343,8 +367,6 @@ TEST_CASE_METHOD(fixture, "short write test", "[fd_storage]")
 
 TEST_CASE_METHOD(fixture, "EAGAIN test", "[fd_storage]")
 {
-    std::cerr << "Note: Log message to stderr is expected\n";
-
     std::size_t sqe_count = 0;
     std::size_t cqe_count = 0;
     std::size_t submit_count = 0;
@@ -382,53 +404,12 @@ TEST_CASE_METHOD(fixture, "EAGAIN test", "[fd_storage]")
     storage_->submit_buffer(span.data(), span.size());
     flush_and_sync();
 
+    REQUIRE(verify_file_contents(1));
+
     // Request should be resubmitted
     REQUIRE(sqe_count == 2);
     REQUIRE(cqe_count == 2);
     REQUIRE(submit_count == 2);
-}
-
-TEST_CASE_METHOD(fixture, "close fail test", "[fd_storage]")
-{
-    std::cerr << "Note: Log message to stderr is expected\n";
-
-    std::size_t sqe_count = 0;
-    std::size_t cqe_count = 0;
-    std::size_t submit_count = 0;
-
-    get_sqe_hook = [&](io_uring* ring)
-    {
-        ++sqe_count;
-        return io_uring_get_sqe(ring);
-    };
-
-#if XTR_IO_URING_POLL
-    peek_cqe_hook =
-#else
-    wait_cqe_hook =
-#endif
-        [&](auto ring, auto cqe)
-    {
-        const int ret = io_uring_wait_cqe(ring, cqe);
-        ++cqe_count;
-        REQUIRE(::io_uring_cqe_get_data(*cqe) == nullptr);
-        (*cqe)->res = -EIO;
-        return ret;
-    };
-
-    submit_hook = [&](io_uring* ring)
-    {
-        ++submit_count;
-        return io_uring_submit(ring);
-    };
-
-    REQUIRE(storage_->reopen() == 0);
-    storage_->sync();
-
-    // Request should not be resubmitted
-    REQUIRE(sqe_count == 1);
-    REQUIRE(cqe_count == 1);
-    REQUIRE(submit_count == 1);
 }
 
 TEST_CASE_METHOD(fixture, "write error test", "[fd_storage]")
@@ -445,40 +426,45 @@ TEST_CASE_METHOD(fixture, "write error test", "[fd_storage]")
         return ret;
     };
 
-    const auto span = storage_->allocate_buffer();
-    storage_->submit_buffer(span.data(), span.size());
+    std::cerr << "Note: Log message to stderr is expected\n";
+
+    send_buffer();
     flush_and_sync();
+}
+
+TEST_CASE_METHOD(fixture, "reopen with unsent buffers", "[fd_storage]")
+{
+    // Send without a flush
+    send_buffer();
+
+    REQUIRE(storage_->reopen() == 0);
+
+    REQUIRE(verify_file_contents(1));
 }
 
 TEST_CASE_METHOD(fixture, "reopen resets file offset", "[fd_storage]")
 {
-    {
-        const auto span = storage_->allocate_buffer();
-        storage_->submit_buffer(span.data(), span.size());
-    }
+    send_buffer();
     flush_and_sync();
 
-    REQUIRE(::unlink(tmp_.path_.c_str()) == 0);
+    const std::string rotated = tmp_.path_ + ".1";
+    REQUIRE(::rename(tmp_.path_.c_str(), rotated.c_str()) == 0);
+
     REQUIRE(storage_->reopen() == 0);
 
-    {
-        const auto span = storage_->allocate_buffer();
-        storage_->submit_buffer(span.data(), span.size());
-    }
+    fill_ = 0;
+    send_buffer();
     flush_and_sync();
 
-    struct stat st{};
-    REQUIRE(::stat(tmp_.path_.c_str(), &st) == 0);
-    REQUIRE(
-        st.st_size == ::off_t(xtr::io_uring_fd_storage::default_buffer_capacity));
+    REQUIRE(verify_file_contents(1));
+    REQUIRE(verify_file_contents(1, rotated.c_str()));
+
+    REQUIRE(::unlink(rotated.c_str()) == 0);
 }
 
 TEST_CASE_METHOD(fixture, "reopen on same file appends to end", "[fd_storage]")
 {
-    {
-        const auto span = storage_->allocate_buffer();
-        storage_->submit_buffer(span.data(), span.size());
-    }
+    send_buffer();
     flush_and_sync();
 
     // Reopen with the file still in place. offset_ must be re-seeded from the
@@ -486,16 +472,27 @@ TEST_CASE_METHOD(fixture, "reopen on same file appends to end", "[fd_storage]")
     // byte 0.
     REQUIRE(storage_->reopen() == 0);
 
-    {
-        const auto span = storage_->allocate_buffer();
-        storage_->submit_buffer(span.data(), span.size());
-    }
+    send_buffer();
     flush_and_sync();
 
-    struct stat st{};
-    REQUIRE(::stat(tmp_.path_.c_str(), &st) == 0);
-    REQUIRE(
-        st.st_size ==
-        ::off_t(xtr::io_uring_fd_storage::default_buffer_capacity * 2));
+    REQUIRE(verify_file_contents(2));
+}
+
+TEST_CASE_METHOD(fixture, "open existing file appends to end", "[fd_storage]")
+{
+    send_buffer();
+
+    storage_.reset();
+
+    xtr::detail::file_descriptor fd(
+        xtr::detail::open_at_end(tmp_.path_.c_str()));
+    REQUIRE(fd);
+
+    storage_ = std::make_unique<test_fd_storage>(fd.release(), tmp_.path_);
+
+    send_buffer();
+    flush_and_sync();
+
+    REQUIRE(verify_file_contents(2));
 }
 #endif

--- a/test/fd_storage.cpp
+++ b/test/fd_storage.cpp
@@ -520,7 +520,7 @@ TEST_CASE_METHOD(fixture, "open existing file appends to end", "[fd_storage]")
     xtr::detail::file_descriptor fd(xtr::detail::open_at_end(tmp_.path_.c_str()));
     REQUIRE(fd);
 
-    storage_ = std::make_unique<test_fd_storage>(fd.release(), tmp_.path_);
+    storage_ = std::make_unique<test_fd_storage>(fd.get(), tmp_.path_);
 
     send_buffer();
     sync();

--- a/test/fd_storage.cpp
+++ b/test/fd_storage.cpp
@@ -185,9 +185,8 @@ namespace
             storage_->flush();
         }
 
-        void flush_and_sync()
+        void sync()
         {
-            storage_->flush();
             storage_->sync();
         }
 
@@ -218,7 +217,7 @@ TEST_CASE_METHOD(fixture, "write test", "[fd_storage]")
     for (std::size_t i = 0; i < n; ++i)
         send_buffer();
 
-    flush_and_sync();
+    sync();
 
     REQUIRE(cqe_count == n);
     REQUIRE(verify_file_contents(n));
@@ -245,7 +244,7 @@ TEST_CASE_METHOD(fixture, "write more than queue size test", "[fd_storage]")
     for (std::size_t i = 0; i < n; ++i)
         send_buffer();
 
-    flush_and_sync();
+    sync();
 
     REQUIRE(cqe_count == n);
     REQUIRE(verify_file_contents(n));
@@ -354,7 +353,7 @@ TEST_CASE_METHOD(fixture, "short write test", "[fd_storage]")
     const auto span = storage_->allocate_buffer();
     REQUIRE(span.size() > missing_size);
     storage_->submit_buffer(span.data(), span.size());
-    flush_and_sync();
+    sync();
 
     REQUIRE(verify_file_contents(1));
 
@@ -400,7 +399,7 @@ TEST_CASE_METHOD(fixture, "EAGAIN test", "[fd_storage]")
     };
 
     storage_->submit_buffer(span.data(), span.size());
-    flush_and_sync();
+    sync();
 
     REQUIRE(verify_file_contents(1));
 
@@ -427,7 +426,7 @@ TEST_CASE_METHOD(fixture, "write error test", "[fd_storage]")
     std::cerr << "Note: Log message to stderr is expected\n";
 
     send_buffer();
-    flush_and_sync();
+    sync();
 }
 
 TEST_CASE_METHOD(fixture, "reopen with unsent buffers", "[fd_storage]")
@@ -443,7 +442,7 @@ TEST_CASE_METHOD(fixture, "reopen with unsent buffers", "[fd_storage]")
 TEST_CASE_METHOD(fixture, "reopen resets file offset", "[fd_storage]")
 {
     send_buffer();
-    flush_and_sync();
+    sync();
 
     const std::string rotated = tmp_.path_ + ".1";
     REQUIRE(::rename(tmp_.path_.c_str(), rotated.c_str()) == 0);
@@ -452,7 +451,7 @@ TEST_CASE_METHOD(fixture, "reopen resets file offset", "[fd_storage]")
 
     fill_ = 0;
     send_buffer();
-    flush_and_sync();
+    sync();
 
     REQUIRE(verify_file_contents(1));
     REQUIRE(verify_file_contents(1, rotated.c_str()));
@@ -463,7 +462,7 @@ TEST_CASE_METHOD(fixture, "reopen resets file offset", "[fd_storage]")
 TEST_CASE_METHOD(fixture, "reopen on same file appends to end", "[fd_storage]")
 {
     send_buffer();
-    flush_and_sync();
+    sync();
 
     // Reopen with the file still in place. offset_ must be re-seeded from the
     // new fd's end-of-file so the next write appends rather than overwriting
@@ -471,7 +470,7 @@ TEST_CASE_METHOD(fixture, "reopen on same file appends to end", "[fd_storage]")
     REQUIRE(storage_->reopen() == 0);
 
     send_buffer();
-    flush_and_sync();
+    sync();
 
     REQUIRE(verify_file_contents(2));
 }
@@ -488,7 +487,7 @@ TEST_CASE_METHOD(fixture, "open existing file appends to end", "[fd_storage]")
     storage_ = std::make_unique<test_fd_storage>(fd.release(), tmp_.path_);
 
     send_buffer();
-    flush_and_sync();
+    sync();
 
     REQUIRE(verify_file_contents(2));
 }

--- a/test/fd_storage.cpp
+++ b/test/fd_storage.cpp
@@ -445,6 +445,53 @@ TEST_CASE_METHOD(fixture, "EAGAIN test", "[fd_storage]")
     REQUIRE(submit_count == 2);
 }
 
+TEST_CASE_METHOD(fixture, "ECANCELED test", "[fd_storage]")
+{
+    std::size_t sqe_count = 0;
+    std::size_t cqe_count = 0;
+    std::size_t submit_count = 0;
+    io_uring_sqe* sqe;
+
+    get_sqe_hook = [&](io_uring* ring)
+    {
+        ++sqe_count;
+        return sqe = io_uring_get_sqe(ring);
+    };
+
+#if XTR_IO_URING_POLL
+    peek_cqe_hook =
+#else
+    wait_cqe_hook =
+#endif
+        [&](auto ring, auto cqe)
+    {
+        const int ret = io_uring_wait_cqe(ring, cqe);
+        if (++cqe_count == 1)
+            (*cqe)->res = -ECANCELED;
+        return ret;
+    };
+
+    const auto span = storage_->allocate_buffer();
+
+    submit_hook = [&](io_uring* ring)
+    {
+        ++submit_count;
+        // Full buffer should be resubmitted
+        REQUIRE(sqe->len == span.size());
+        return io_uring_submit(ring);
+    };
+
+    storage_->submit_buffer(span.data(), span.size());
+    sync();
+
+    REQUIRE(verify_file_contents(1));
+
+    // Request should be resubmitted
+    REQUIRE(sqe_count == 2);
+    REQUIRE(cqe_count == 2);
+    REQUIRE(submit_count == 2);
+}
+
 TEST_CASE_METHOD(fixture, "write error test", "[fd_storage]")
 {
 #if XTR_IO_URING_POLL

--- a/test/fd_storage.cpp
+++ b/test/fd_storage.cpp
@@ -20,24 +20,31 @@
 
 #include "xtr/config.hpp"
 
-#if XTR_USE_IO_URING
 #include "xtr/detail/memory_mapping.hpp"
 #include "xtr/io/detail/open.hpp"
+#include "xtr/io/fd_storage.hpp"
 #include "xtr/io/io_uring_fd_storage.hpp"
+#include "xtr/io/posix_fd_storage.hpp"
 
 #include "temp_file.hpp"
 
 #include <catch2/catch.hpp>
+#if XTR_USE_IO_URING
 #include <liburing.h>
+#endif
 
 #include <algorithm>
 #include <cerrno>
 #include <functional>
 #include <iostream>
+#include <stdexcept>
+#include <vector>
 
 #include <dlfcn.h>
 #include <sys/stat.h>
 #include <unistd.h>
+
+#if XTR_USE_IO_URING
 
 #if __cpp_exceptions
 #define XTR_REQUIRE_NOERROR(X) REQUIRE_NOTHROW(X)
@@ -278,40 +285,69 @@ TEST_CASE_METHOD(fixture, "reopen with writes queued", "[fd_storage]")
 
 TEST_CASE_METHOD(fixture, "submission queue full on submit", "[fd_storage]")
 {
-    // First send a buffer so that there is a completion event to wait on
-    send_buffer();
-    flush();
-
     // Return null when an SQE is requested (submission queue full) to cause
-    // progress to block/spin waiting for a CQE to complete (which implies a
-    // SQE is then available)
+    // progress to block/spin until an SQE is available
     get_sqe_hook = [&](io_uring*) { return nullptr; };
 
-    bool wait_cqe_called = false;
+    bool submit_called = false;
 
 #if XTR_IO_URING_POLL
     sqring_wait_hook =
 #else
-    wait_cqe_hook =
+    submit_hook =
 #endif
         [&](auto... args)
     {
-        if (!wait_cqe_called)
+        if (!submit_called)
         {
-            wait_cqe_called = true;
+            submit_called = true;
             get_sqe_hook = io_uring_get_sqe;
         }
 #if XTR_IO_URING_POLL
         return io_uring_sqring_wait(args...);
 #else
-        return io_uring_wait_cqe(args...);
+        return io_uring_submit(args...);
 #endif
     };
 
-    // Try to submit a buffer, get_sqe returns null so wait_cqe should be called
+    // Try to submit a buffer, get_sqe returns null so submit should be called
     send_buffer();
 
-    REQUIRE(wait_cqe_called);
+    REQUIRE(submit_called);
+}
+
+TEST_CASE_METHOD(fixture, "sqe flags test", "[fd_storage]")
+{
+    std::vector<io_uring_sqe*> sqes;
+
+    get_sqe_hook = [&](io_uring* ring)
+    {
+        io_uring_sqe* const sqe = io_uring_get_sqe(ring);
+        sqes.push_back(sqe);
+        return sqe;
+    };
+
+    send_buffer();
+    send_buffer();
+    flush();
+    send_buffer();
+
+    REQUIRE(sqes.size() == 3);
+
+    // All writes are hardlinked so that they complete in order
+    REQUIRE((sqes[0]->flags & IOSQE_IO_HARDLINK) != 0);
+    REQUIRE((sqes[1]->flags & IOSQE_IO_HARDLINK) != 0);
+    REQUIRE((sqes[2]->flags & IOSQE_IO_HARDLINK) != 0);
+
+    // The first SQE of each batch has IOSQE_IO_DRAIN set, with flush()
+    // ending the current batch
+    REQUIRE((sqes[0]->flags & IOSQE_IO_DRAIN) != 0);
+    REQUIRE((sqes[1]->flags & IOSQE_IO_DRAIN) == 0);
+    REQUIRE((sqes[2]->flags & IOSQE_IO_DRAIN) != 0);
+
+    sync();
+
+    REQUIRE(verify_file_contents(3));
 }
 
 TEST_CASE_METHOD(fixture, "short write test", "[fd_storage]")
@@ -491,4 +527,63 @@ TEST_CASE_METHOD(fixture, "open existing file appends to end", "[fd_storage]")
 
     REQUIRE(verify_file_contents(2));
 }
+
+#if __cpp_exceptions
+TEST_CASE("non-seekable fd is rejected", "[fd_storage]")
+{
+    int fds[2];
+    REQUIRE(::pipe(fds) == 0);
+    xtr::detail::file_descriptor rfd(fds[0]);
+    xtr::detail::file_descriptor wfd(fds[1]);
+
+    REQUIRE_THROWS_AS(
+        xtr::io_uring_fd_storage(wfd.get()),
+        std::invalid_argument);
+}
+
+TEST_CASE("O_APPEND fd is rejected", "[fd_storage]")
+{
+    temp_file tmp;
+    xtr::detail::file_descriptor fd(tmp.path_.c_str(), O_WRONLY | O_APPEND);
+    REQUIRE(fd);
+
+    REQUIRE_THROWS_AS(
+        xtr::io_uring_fd_storage(fd.get(), tmp.path_),
+        std::invalid_argument);
+}
 #endif
+#endif
+
+TEST_CASE("make_fd_storage falls back to posix_fd_storage for pipes", "[fd_storage]")
+{
+    int fds[2];
+    REQUIRE(::pipe(fds) == 0);
+    xtr::detail::file_descriptor rfd(fds[0]);
+    xtr::detail::file_descriptor wfd(fds[1]);
+
+    const auto storage = xtr::make_fd_storage(wfd.get());
+
+    REQUIRE(dynamic_cast<xtr::posix_fd_storage*>(storage.get()) != nullptr);
+}
+
+TEST_CASE("posix_fd_storage truncate test", "[fd_storage]")
+{
+    temp_file tmp;
+    xtr::posix_fd_storage storage(tmp.fd_.get(), tmp.path_);
+
+    // Reopen so that the storage holds a library-created fd (with O_APPEND)
+    REQUIRE(storage.reopen() == 0);
+
+    char c = 'x';
+    storage.submit_buffer(&c, 1);
+
+    // If O_APPEND is not set then this write would land at offset 1,
+    // leaving a hole
+    REQUIRE(::truncate(tmp.path_.c_str(), 0) == 0);
+
+    storage.submit_buffer(&c, 1);
+
+    struct stat st{};
+    REQUIRE(::stat(tmp.path_.c_str(), &st) == 0);
+    REQUIRE(st.st_size == 1);
+}


### PR DESCRIPTION
io_uring backend improvements: Fix log rotation, fix appending to existing file, ensure all buffers are flushed during sync(), fix bug where out of order writes could result in a hole, handle io_uring_wait_cqe returning EINTR, fix fd leak in make_fd_storage, make io_uring availability check more robust. Note that the io_uring backend now requires kernel 5.5+.