### PR TITLE
Fix broken Godbolt format-string example ({fmt} 12.0.0)

### DIFF
--- a/docs-src/guide.rst
+++ b/docs-src/guide.rst
@@ -122,7 +122,7 @@ Example
     XTR_LOG(s, "Hello {}", 123.456); // Hello 123.456
     XTR_LOG(s, "Hello {:.1f}", 123.456); // Hello 123.1
 
-View this example on `Compiler Explorer <https://godbolt.org/z/zxs7WThM6>`__.
+View this example on `Compiler Explorer <https://godbolt.org/z/xn3z5fnj3>`__.
 
 .. _copy_val_ref:
 


### PR DESCRIPTION
## Summary
- The format-string Compiler Explorer example (`zxs7WThM6`) still pinned `{fmt}` 7.1.3 and no longer compiles against current XTR.
- Replaced it with a new shortlink (`xn3z5fnj3`) that uses `{fmt}` 12.0.0, matching the other guide examples.

## Test plan
- [x] Compiled the new shortlink via the Compiler Explorer API with `{fmt}` 12.0.0 (success)
- [x] Confirmed the old shortlink fails with `{fmt}` 7.1.3 and succeeds after upgrading to 12.0.0
- [x] Verified the other 13 guide Godbolt links already use `{fmt}` 12.0.0 and compile successfully
- [x] Open https://godbolt.org/z/xn3z5fnj3 and confirm it builds/runs in the browser